### PR TITLE
Support GuzzleHTTP 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.3"
+        "guzzlehttp/guzzle": "^6.3|^7.0"
     },
     "require-dev": {
         "phpdocumentor/phpdocumentor": "dev-master",


### PR DESCRIPTION
https://github.com/guzzle/guzzle/blob/7.0.0/UPGRADING.md#60-to-70

GuzzleHTTP 7.x seems to work flawlessly 👍 .

_Please add a tag after checking / merging._