### PR TITLE
docs: update build status badge [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://app.travis-ci.com/prismicio/php-kit.svg?branch=master "Travis build")](https://app.travis-ci.com/prismicio/php-kit)
+[![Build Status](https://app.travis-ci.com/prismicio-community/php-kit.svg?branch=master "Travis build")](https://app.travis-ci.com/github/prismicio-community/php-kit)
 
 # PHP development kit for Prismic
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![alt text](https://travis-ci.org/prismicio/php-kit.png?branch=master "Travis build")](https://travis-ci.org/prismicio/php-kit)
+[![Build Status](https://app.travis-ci.com/prismicio/php-kit.svg?branch=master "Travis build")](https://app.travis-ci.com/prismicio/php-kit)
 
 # PHP development kit for Prismic
 


### PR DESCRIPTION
This PR updates the build status badge in the readme file. Currently, the Badge links to an [old migrated page](https://travis-ci.org/github/prismicio/php-kit).
This small change points to the [new and correct url](https://app.travis-ci.com/github/prismicio/php-kit).