### PR TITLE
Add CI Workflow for GitHub Actions

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,0 +1,14 @@
+name: "Continuous Integration"
+
+on:
+  pull_request:
+  push:
+    branches:
+        - 'main'
+        - 'master'
+        - '[0-9]+.[0-9]+.x'
+    tags:
+
+jobs:
+  ci:
+    uses: laminas/workflow-continuous-integration/.github/workflows/continuous-integration.yml@1.x


### PR DESCRIPTION
@c0nst4ntin - This CI workflow should help get #190 over the line. It will also take care of `phpcs`, `psalm` and composer require checker for future ref. Feel free to close this PR if it's not useful. Obviously, nothing will pass on main or master here.