### PR TITLE
fix (#152): remove last new line from rich text blocks

### DIFF
--- a/src/Prismic/Dom/RichText.php
+++ b/src/Prismic/Dom/RichText.php
@@ -32,7 +32,7 @@ class RichText
             }
         }
 
-        return $result;
+        return substr($result, 0, -1);
     }
 
     /**

--- a/src/Prismic/Dom/RichText.php
+++ b/src/Prismic/Dom/RichText.php
@@ -32,7 +32,7 @@ class RichText
             }
         }
 
-        return substr($result, 0, -1);
+        return trim($result);
     }
 
     /**

--- a/tests/Prismic/Dom/RichTextTest.php
+++ b/tests/Prismic/Dom/RichTextTest.php
@@ -41,6 +41,8 @@ class RichTextTest extends TestCase
 
         $this->assertEquals($expected, RichText::asText($this->richText->description));
         $this->assertEquals($expected, RichText::asText($this->richText->description, $this->linkResolver));
+
+        $this->assertStringEndsNotWith("\n", RichText::asText($this->richText->description));
     }
 
     public function testAsHtml()

--- a/tests/Prismic/Dom/RichTextTest.php
+++ b/tests/Prismic/Dom/RichTextTest.php
@@ -20,9 +20,27 @@ class RichTextTest extends TestCase
 
     public function testAsText()
     {
-        $expected = "The title\n";
-        $actual = RichText::asText($this->richText->title);
-        $this->assertEquals($expected, $actual);
+        $expected = (
+            "Heading 1\n".
+            "Heading 2\n".
+            "Heading 3\n".
+            "Heading 4\n".
+            "Heading 5\n".
+            "Heading 6\n".
+            "Paragraph em and strong\n".
+            "Paragraph Web link and media link\n".
+            "Preformatted block\n".
+            "Help\n".
+            "Revolver\n".
+            "Abbey Road\n".
+            "John\n".
+            "Paul\n".
+            "George\n".
+            "Ringo"
+        );
+
+        $this->assertEquals($expected, RichText::asText($this->richText->description));
+        $this->assertEquals($expected, RichText::asText($this->richText->description, $this->linkResolver));
     }
 
     public function testAsHtml()


### PR DESCRIPTION
This PR aims to solve Issue #152 

As mentioned by @cloakedninjas it does not make sense to have a trailing `\n` on the last block in `RichText::asText()`.

I implemented a solution like the one mentioned in the issue and updated and extended the Tests for the `asText` function.