### PR TITLE
feat: escape link target around images

### DIFF
--- a/src/Prismic/Dom/RichText.php
+++ b/src/Prismic/Dom/RichText.php
@@ -282,7 +282,7 @@ class RichText
                 $link = property_exists($element, 'linkTo') ? Link::asUrl($element->linkTo, $linkResolver) : null;
 
                 $target     = property_exists($element, 'linkTo') ? ($element->linkTo->target ?? null) : null;
-                $targetCode = $target ? ' target="' . $target . '"' : '';
+                $targetCode = $target ? ' target="' . htmlentities($target) . '"' : '';
 
                 return (
                     '<p class="block-img' . (isset($element->label) ? (' ' . $element->label) : '') . '">' .


### PR DESCRIPTION
Escapes the link target around images inside of a rich-text field which was introduced by #194 