### PR TITLE
ci: add GitHub Actions CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: apc, apcu
-                  ini-file: tests/apc.ini
+                  extensions: apcu
+                  ini-values: apc.enable=1, apc.enable_cli=1
 
             - name: Checkout
               uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
 
             - name: Install dependencies
               run: composer install --prefer-dist
@@ -64,7 +63,6 @@ jobs:
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-                  restore-keys: ${{ runner.os }}-composer-
 
             - name: Test
               run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   extensions: apc, apcu
+                  ini-file: tests/apc.ini
 
             - name: Checkout
               uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,40 +3,7 @@ name: ci
 on: push
 
 jobs:
-    prepare:
-        name: Prepare (${{ matrix.os}}, PHP ${{ matrix.php }})
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: [ubuntu-latest]
-                php: ["8.0", "8.1", "8.2"]
-
-        steps:
-            - name: Set up PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  tools: composer
-                  extensions: apcu
-
-            - name: Checkout
-              uses: actions/checkout@master
-
-            - name: Get composer cache directory
-              id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-
-            - name: Cache dependencies
-              uses: actions/cache@v3
-              with:
-                  path: ${{ steps.composer-cache.outputs.dir }}
-                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
-
-            - name: Install dependencies
-              run: composer install --prefer-dist
-
     suite:
-        needs: prepare
         name: Suite (${{ matrix.os }}, PHP ${{ matrix.php }})
         runs-on: ${{ matrix.os }}
         strategy:
@@ -59,11 +26,14 @@ jobs:
               id: composer-cache
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
-            - name: Retrieve dependencies
+            - name: Cache dependencies
               uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
 
             - name: Test
               run: composer test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: ci
+
+on: push
+
+jobs:
+    prepare:
+        name: Prepare (${{ matrix.os}}, Node ${{ matrix.node }})
+        runs-on: ${{ matrix.os }}
+        strategy:
+            matrix:
+                os: [ubuntu-latest]
+                php: ["8.0", "8.1", "8.2"]
+
+        steps:
+            - name: Set up PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: apcu
+
+            - name: Checkout
+              uses: actions/checkout@master
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache dependencies
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install dependencies
+              run: composer install --prefer-dist
+
+    suite:
+        needs: prepare
+        name: Suite (${{ matrix.os }}, PHP ${{ matrix.php }})
+        runs-on: ${{ matrix.os }}
+        strategy:
+            fail-fast: false
+            matrix:
+                os: [ubuntu-latest]
+                php: ["8.0", "8.1", "8.2"]
+
+        steps:
+            - name: Set up PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: apcu
+
+            - name: Checkout
+              uses: actions/checkout@master
+
+            - name: Cache dependencies
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Test
+              run: composer test
+
+            - name: Lint
+              run: composer cs-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,11 @@ jobs:
             - name: Checkout
               uses: actions/checkout@master
 
-            - name: Cache dependencies
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Retrieve dependencies
               uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
-                  extensions: apcu
+                  extensions: apc, apcu
 
             - name: Checkout
               uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php }}
+                  tools: composer
                   extensions: apcu
 
             - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on: push
 
 jobs:
     prepare:
-        name: Prepare (${{ matrix.os}}, Node ${{ matrix.node }})
+        name: Prepare (${{ matrix.os}}, PHP ${{ matrix.php }})
         runs-on: ${{ matrix.os }}
         strategy:
             matrix:


### PR DESCRIPTION
This PR adds a basic GitHub Actions workflow to run tests.

It replaces the previous Travis CI workflow.
